### PR TITLE
Simplify newline search

### DIFF
--- a/1brc/App.cs
+++ b/1brc/App.cs
@@ -73,8 +73,8 @@ namespace _1brc
 
                 var newPos = pos + chunkSize;
                 var sp = new ReadOnlySpan<byte>(_pointer + newPos, (int)chunkSize);
-                var idx = IndexOfNewlineChar(sp, out var stride);
-                newPos += idx + stride;
+                var idx = IndexOfNewlineChar(sp);
+                newPos += idx;
                 var len = newPos - pos;
                 chunks.Add((pos, (int)(len)));
                 pos = newPos;
@@ -145,21 +145,12 @@ namespace _1brc
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static int IndexOfNewlineChar(ReadOnlySpan<byte> span, out int stride)
+        internal static int IndexOfNewlineChar(ReadOnlySpan<byte> span)
         {
-            stride = default;
-            int idx = span.IndexOfAny((byte)'\n', (byte)'\r');
+            int idx = span.IndexOf((byte)'\n');
             if ((uint)idx < (uint)span.Length)
             {
-                stride = 1;
-                if (span[idx] == '\r')
-                {
-                    int nextCharIdx = idx + 1;
-                    if ((uint)nextCharIdx < (uint)span.Length && span[nextCharIdx] == '\n')
-                    {
-                        stride = 2;
-                    }
-                }
+                idx++;
             }
 
             return idx;


### PR DESCRIPTION
The newline scanner seems to include line endings and its code looks very similar to how CoreLib's line iterator is implemented. Because the only line endings that are encountered are either `CRLF` or `LF`, there is no need to scan for *just* `CR`s with `.IndexOfAny` which are not valid line endings on Windows or Unix systems.

This is a very quick change and I have not looked into other code in this solution, just something that stood out to me because I worked on a similar problem some time ago here: https://github.com/U8String/U8String/blob/main/Sources/Primitives/U8Enumerators.cs#L505-L536